### PR TITLE
Fix docs on ecs_cluster_id vs ecs_cluster_name

### DIFF
--- a/.changeset/quick-jokes-confess.md
+++ b/.changeset/quick-jokes-confess.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-proxy-ecs": patch
+---
+
+Fix documentation on ecs_cluster_id and ecs_cluster_name variables

--- a/variables.tf
+++ b/variables.tf
@@ -57,13 +57,13 @@ variable "release_tag" {
 
 
 variable "ecs_cluster_id" {
-  description = "Identifies the Amazon Elastic Container Service (ECS) cluster for deployment."
+  description = "The ARN of the Amazon Elastic Container Service (ECS) cluster for deployment."
   type        = string
 }
 
 
 variable "ecs_cluster_name" {
-  description = "Identifies the Amazon Elastic Container Service (ECS) cluster for deployment."
+  description = "The name of Amazon Elastic Container Service (ECS) cluster for deployment."
   type        = string
 }
 


### PR DESCRIPTION
Currently it is unclear that these mean different things.
