### PR TITLE
Relax the version constraint on the Common Fate Terraform provider

### DIFF
--- a/.changeset/five-chairs-cross.md
+++ b/.changeset/five-chairs-cross.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-proxy-ecs": patch
+---
+
+Fix version constraint for the Common Fate Terraform provider to allow minor version updates.

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     commonfate = {
       source  = "common-fate/commonfate"
-      version = "~> 2.25.3"
+      version = "~> 2.25"
     }
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
The current version is too strict and does not permit usage of v2.26.
See: https://developer.hashicorp.com/terraform/language/expressions/version-constraints#-3